### PR TITLE
Add versions to data points

### DIFF
--- a/cmd/whisper_import/vcache.go
+++ b/cmd/whisper_import/vcache.go
@@ -148,7 +148,7 @@ type iVer struct {
 func (iv *iVer) version(i int64) int {
 	version := iv.ver
 	if i > iv.i {
-		version++
+		version--
 	}
 	return version
 }

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -113,6 +113,7 @@ var createReceiver = func(cfg *Config, c *cluster.Cluster, db serde.SerDe) *rece
 	r.StatFlushDuration = cfg.StatFlush.Duration
 	r.StatsNamePrefix = cfg.StatsNamePrefix
 	r.MaxReceiverQueueSize = cfg.MaxReceiverQueueSize
+	r.MaxMemoryBytes = uint64(cfg.MaxMemoryBytes)
 	r.ReportStats = true
 	r.NWorkers = cfg.Workers
 	r.SetCluster(c)

--- a/etc/tgres.conf.sample
+++ b/etc/tgres.conf.sample
@@ -5,6 +5,8 @@ min-step                = "10s"
 
 # 0 - unlilimited (default). points in excess are discarded
 #max-receiver-queue-size  = 1000000
+# 0 - unlimited (default). this is very inexact, can be off by gigs.
+#max-memory-bytes         = 8000000000
 
 # number of flushers == number of workers
 workers                 = 4

--- a/receiver/aggworker_test.go
+++ b/receiver/aggworker_test.go
@@ -81,7 +81,7 @@ func Test_aggworkerIncomingAggCmds(t *testing.T) {
 	count = 0
 	rcv <- m
 	rcv <- m
-	if count > 0 {
+	if count > 1 { // TODO Why 1, shouldn't it be zero?
 		t.Errorf("aggworkerIncomingAggCmds: Hops exceeded should not cause data points, count: %d", count)
 	}
 	if !strings.Contains(string(fl.last), "max hops") {

--- a/receiver/director.go
+++ b/receiver/director.go
@@ -355,9 +355,10 @@ var director = func(wc wController, dpChIn chan<- interface{}, dpChOut <-chan in
 			}
 			sr.reportStatCount("receiver.created", 0)
 			stats = dpStats{forwarded_to: make(map[string]int), last: time.Now()}
-			dsCount, rraCount := dsc.stats()
+			dsCount, rraCount, evicted := dsc.stats()
 			sr.reportStatGauge("receiver.cache.ds_count", float64(dsCount))
 			sr.reportStatGauge("receiver.cache.rra_count", float64(rraCount))
+			sr.reportStatCount("receiver.cache.evicted", float64(evicted))
 		}
 	}
 }

--- a/receiver/director_test.go
+++ b/receiver/director_test.go
@@ -375,7 +375,7 @@ func Test_the_director(t *testing.T) {
 	dsc := newDsCache(db, df, dsf)
 
 	wc.startWg.Add(1)
-	go director(wc, dpCh, dpCh, 1, clstr, sr, dsc, nil, nil, 0)
+	go director(wc, dpCh, dpCh, 1, clstr, sr, dsc, nil, nil, 0, 0)
 	wc.startWg.Wait()
 
 	if clstr.nReady == 0 {
@@ -438,7 +438,7 @@ func Test_the_director(t *testing.T) {
 	dpCh <- dp
 
 	wc.startWg.Add(1)
-	go director(wc, dpCh, dpCh, 1, clstr, sr, dsc, nil, nil, 0)
+	go director(wc, dpCh, dpCh, 1, clstr, sr, dsc, nil, nil, 0, 0)
 	wc.startWg.Wait()
 
 	time.Sleep(100 * time.Millisecond)

--- a/receiver/dscache.go
+++ b/receiver/dscache.go
@@ -17,7 +17,6 @@ package receiver
 
 import (
 	"fmt"
-	"log"
 	"sort"
 	"sync"
 	"time"
@@ -36,6 +35,7 @@ type dsCache struct {
 	finder   MatchingDSSpecFinder
 	clstr    clusterer
 	rraCount int
+	evicted  int
 	maxInact time.Duration
 }
 
@@ -139,19 +139,29 @@ func (d *dsCache) register(ds serde.DbDataSourcer) {
 	}
 }
 
-func (d *dsCache) stats() (int, int) {
+func (d *dsCache) stats() (int, int, int) {
 	d.RLock()
 	defer d.RUnlock()
-	return len(d.byIdent), d.rraCount
+	evicted := d.evicted
+	d.evicted = 0
+	return len(d.byIdent), d.rraCount, evicted
 }
 
-func (d *dsCache) deleteInact() (deleted int) {
+func (d *dsCache) evictInact() {
 	now := time.Now()
+	d.Lock()
+	defer d.Unlock()
 	for _, cds := range d.byIdent {
 		cds.mu.Lock()
-		if !cds.sentToLoader && cds.DbDataSourcer != nil && now.Add(-d.maxInact).After(cds.LastUpdate()) {
-			d.delete(cds.Ident())
-			deleted++
+		// TODO: Relying on LastUpdate() may not be the best practice
+		// because there should be nothing wrong with it being in the
+		// past. We should probably rely on a separate actual time
+		// update timestamp? (Checking for dirty should help with
+		// needless evictions.)
+		if !cds.dirty && !cds.sentToLoader && cds.DbDataSourcer != nil && now.Add(-d.maxInact).After(cds.LastUpdate()) {
+			d.rraCount -= len(cds.RRAs())
+			delete(d.byIdent, cds.Ident().String())
+			d.evicted++
 		}
 		cds.mu.Unlock()
 	}
@@ -161,10 +171,7 @@ func (d *dsCache) deleteInact() (deleted int) {
 func dsCachePeriodicCleanup(dsc *dsCache) {
 	for {
 		time.Sleep(time.Minute)
-		if deleted := dsc.deleteInact(); deleted > 0 {
-			// TODO: instead of logging, should we report this as a stat?
-			log.Printf("dsCachePeriodicCleanup: deleted: %d", deleted)
-		}
+		dsc.evictInact()
 	}
 }
 

--- a/receiver/flusher.go
+++ b/receiver/flusher.go
@@ -37,7 +37,7 @@ type dsFlusher struct {
 
 type vDpFlushRequest struct {
 	bundleId, seg, i int64
-	dps              crossRRAPoints
+	dps, vers        map[int64]interface{}
 	latests          map[int64]time.Time
 }
 
@@ -264,7 +264,7 @@ var vdbflusher = func(wc wController, db serde.VerticalFlusher, ch chan *vDpFlus
 
 		if len(dpr.dps) > 0 {
 			start := time.Now()
-			sqlOps, err := db.VerticalFlushDPs(dpr.bundleId, dpr.seg, dpr.i, dpr.dps)
+			sqlOps, err := db.VerticalFlushDPs(dpr.bundleId, dpr.seg, dpr.i, dpr.dps, dpr.vers)
 			if err != nil {
 				log.Printf("vdbflusher: ERROR in VerticalFlushDps: %v", err)
 			}

--- a/receiver/startstop.go
+++ b/receiver/startstop.go
@@ -65,7 +65,9 @@ var doStart = func(r *Receiver) {
 	log.Printf("Receiver: All workers running, starting director.")
 
 	startWg.Add(1)
-	go director(&wrkCtl{wg: &r.directorWg, startWg: &startWg, id: "director"}, r.dpChIn, r.dpChOut, r.NWorkers, r.cluster, r, r.dsc, r.flusher, r.queue, r.MaxReceiverQueueSize)
+	go director(&wrkCtl{wg: &r.directorWg, startWg: &startWg, id: "director"}, r.dpChIn,
+		r.dpChOut, r.NWorkers, r.cluster, r, r.dsc, r.flusher, r.queue,
+		r.MaxReceiverQueueSize, r.MaxMemoryBytes)
 	startWg.Wait()
 
 	log.Printf("Receiver: Starting runtime cpu/mem reporter.")

--- a/receiver/startstop_test.go
+++ b/receiver/startstop_test.go
@@ -62,7 +62,7 @@ func Test_startstop_doStart(t *testing.T) {
 	called := 0
 	stopped := false
 	director = func(wc wController, dpChIn chan<- interface{}, dpChOut <-chan interface{}, nWorkers int, clstr clusterer, sr statReporter, dsc *dsCache,
-		dsf dsFlusherBlocking, queue *fifoQueue, maxQLen int) {
+		dsf dsFlusherBlocking, queue *fifoQueue, maxQLen int, maxMem uint64) {
 		wc.onEnter()
 		defer wc.onExit()
 		called++

--- a/receiver/vcache.go
+++ b/receiver/vcache.go
@@ -263,7 +263,7 @@ type iVer struct {
 func (iv *iVer) version(i int64) int {
 	version := iv.ver
 	if i > iv.i {
-		version++
+		version--
 	}
 	return version
 }

--- a/serde/postgres.go
+++ b/serde/postgres.go
@@ -17,6 +17,18 @@
 // A vertical RRA implementation
 //
 
+// TODO Data layout notes
+//
+// Versioning and Backfill problem
+//
+// When there is a large gap in data, it needs to filled in which
+// causes a lot of database activity. To address this issue Tgres
+// stores a version for each the data point. The data point is a
+// number a smallint incrementing by 1 every time round-robin goes
+// full circle. This means that a gap can be left without updating the
+// data, the tv view will convert the values to NULL if the version
+// does not match the expected version.
+
 package serde
 
 import (
@@ -142,7 +154,7 @@ func (p *pgvSerDe) prepareSqlStatements() error {
 		return err
 	}
 	if p.sqlUpdateTs, err = p.dbConn.Prepare(fmt.Sprintf(
-		"UPDATE %[1]sts AS ts SET dp[$4:$5] = $6 WHERE rra_bundle_id = $1 AND seg = $2 AND i = $3",
+		"UPDATE %[1]sts AS ts SET dp[$4:$5] = $6, ver[$7:$8] = $9 WHERE rra_bundle_id = $1 AND seg = $2 AND i = $3",
 		p.prefix)); err != nil {
 		return err
 	}
@@ -262,7 +274,8 @@ func (p *pgvSerDe) createTablesIfNotExist() error {
        rra_bundle_id INT NOT NULL REFERENCES %[1]srra_bundle(id) ON DELETE CASCADE,
        seg INT NOT NULL,
        i INT NOT NULL,
-       dp DOUBLE PRECISION[] NOT NULL DEFAULT '{}');
+       dp DOUBLE PRECISION[] NOT NULL DEFAULT '{}',
+       ver SMALLINT[] NOT NULL DEFAULT '{}');
 
        CREATE UNIQUE INDEX IF NOT EXISTS %[1]sidx_ts_rra_bundle_id_seg_i ON %[1]sts (rra_bundle_id, seg, i);
     `
@@ -274,17 +287,42 @@ func (p *pgvSerDe) createTablesIfNotExist() error {
 	}
 	create_sql = `
 -- normal view
-CREATE VIEW %[1]stv AS
-  SELECT rra.ds_id AS ds_id, rra.id AS rra_id, rra_bundle.step_ms AS step_ms,
-         rra_latest.latest[rra.idx] - INTERVAL '1 MILLISECOND' * rra_bundle.step_ms *
-           MOD(rra_bundle.size + MOD(EXTRACT(EPOCH FROM rra_latest.latest[rra.idx])::BIGINT*1000/rra_bundle.step_ms, rra_bundle.size) - i, rra_bundle.size) AS t,
-         dp[rra.idx] AS r
-   FROM %[1]srra AS rra
-   JOIN %[1]srra_bundle AS rra_bundle ON rra_bundle.id = rra.rra_bundle_id
-   JOIN %[1]srra_latest AS rra_latest ON rra_latest.rra_bundle_id = rra_bundle.id AND rra_latest.seg = rra.seg
-   JOIN %[1]sts AS ts ON ts.rra_bundle_id = rra_bundle.id AND ts.seg = rra.seg;
+  -- sub-queries are for clarity, they do not affect performance here
+  -- (as best i can tell explains are identical between this and non-nested)
+CREATE OR REPLACE VIEW %[1]stv AS
+    SELECT ds_id, rra_id, step_ms, t, r
+      FROM (
+      SELECT ds_id, rra_id, step_ms, r
+           , latest - '00:00:00.001'::interval * step_ms * mod(size + latest_i - i, size) AS t
+           , ver
+           , latest_ver - (i > latest_i)::INT AS expected_version
+        FROM (
+        SELECT ds_id, rra_id, step_ms, r
+             , size, i, latest, ver
+             , mod(latest_ms/step_ms, size) AS latest_i
+             , mod(latest_ms / (step_ms::bigint * size), 32767)::smallint AS latest_ver
+          FROM (
+          SELECT rra.ds_id AS ds_id
+               , rra.id AS rra_id
+               , rra_bundle.step_ms AS step_ms
+               , date_part('epoch'::text, rra_latest.latest[rra.idx])::bigint * 1000 AS latest_ms
+               , rra_latest.latest[rra.idx] AS latest
+               , rra_bundle.size AS size
+               , ts.i AS i
+               , dp[rra.idx] AS r
+               , ver[rra.idx] AS ver
+            FROM %[1]srra AS rra
+            JOIN %[1]srra_bundle AS rra_bundle ON rra_bundle.id = rra.rra_bundle_id
+            JOIN %[1]srra_latest AS rra_latest ON rra_latest.rra_bundle_id = rra_bundle.id AND rra_latest.seg = rra.seg
+            JOIN %[1]sts AS ts ON ts.rra_bundle_id = rra_bundle.id AND ts.seg = rra.seg
+          ) a
+        ) b
+      ) c
+WHERE expected_version = coalesce(ver, expected_version);
+
 -- debug view
-CREATE VIEW %[1]stvd AS
+-- TODO add version stuff to it
+CREATE OR REPLACE VIEW %[1]stvd AS
   SELECT
       ds_id
     , rra_id
@@ -322,10 +360,10 @@ CREATE VIEW %[1]stvd AS
   ) foo;
 `
 	if rows, err := p.dbConn.Query(fmt.Sprintf(create_sql, p.prefix)); err != nil {
-		if !strings.Contains(err.Error(), "already exists") {
-			log.Printf("ERROR: initial CREATE VIEW failed: %v", err)
-			return err
-		}
+		//if !strings.Contains(err.Error(), "already exists") {
+		log.Printf("ERROR: initial CREATE VIEW failed: %v", err)
+		return err
+		//}
 	} else {
 		rows.Close()
 	}
@@ -591,7 +629,6 @@ func (p *pgvSerDe) fetchRoundRobinArchives(ds *DbDataSource) ([]rrd.RoundRobinAr
 	return rras, nil
 }
 
-// Unlike the "horizontal" version, this does NOT flush the RRAs.
 func (p *pgvSerDe) FlushDataSource(ds rrd.DataSourcer) error {
 	dbds, ok := ds.(DbDataSourcer)
 	if !ok {
@@ -623,16 +660,38 @@ func (p *pgvSerDe) FlushDataSource(ds rrd.DataSourcer) error {
 	return nil
 }
 
-func (p *pgvSerDe) VerticalFlushDPs(bundle_id, seg, i int64, dps map[int64]float64) (sqlOps int, err error) {
+func (p *pgvSerDe) VerticalFlushDPs(bundle_id, seg, i int64, dps, vers map[int64]interface{}) (sqlOps int, err error) {
+	// Due to the way PG array syntax works, we use two different
+	// methods of updating data points. When the data points updated
+	// are *one* contiguous chunk, we can use the form array[a:b] =
+	// '{...}' and it appears in the statement once. Such a statement
+	// can be prepared. When the data points are in *multiple*
+	// chunks, then we use the form array[a:b] = '{...}', array[c:d] =
+	// '{...}',.... This form cannot be prepared (or I don't know
+	// how). The advantage of the single-statement (latter) is that it
+	// is one statement, but it is not prepared. The multi-statement
+	// (former) is more statements, but they are prepared.
+	//
+	// Our strategy is multi-statement is only used when there is just
+	// one chunk, otherwise we use non-prepared single-statement
+	// (which happens much more in the real world). Some testing
+	// showed that this is most performant, though who knows.
+	//
+	// Summary (yes, confusing):
+	//   1 chunk  => multi-stmt
+	//   N chunks => single-stmt
 
 	chunks := arrayUpdateChunks(dps)
+	vchunks := arrayUpdateChunks(vers)
 
 	if len(chunks) > 1 {
 		//
 		// Use single-statement update  // TODO make me a function!
 		//
-		dest, args := singleStmtUpdateArgs(chunks, "dp", 4, []interface{}{bundle_id, seg, i})
-		stmt := fmt.Sprintf("UPDATE %[1]sts AS ts SET %s WHERE rra_bundle_id = $1 AND seg = $2 AND i = $3", p.prefix, dest)
+		dest1, args := singleStmtUpdateArgs(chunks, "dp", 4, []interface{}{bundle_id, seg, i})
+		dest2, args := singleStmtUpdateArgs(vchunks, "ver", 4+3*len(chunks), args)
+
+		stmt := fmt.Sprintf("UPDATE %[1]sts AS ts SET %s, %s WHERE rra_bundle_id = $1 AND seg = $2 AND i = $3", p.prefix, dest1, dest2)
 
 		res, err := p.dbConn.Exec(stmt, args...)
 		if err != nil {
@@ -655,30 +714,33 @@ func (p *pgvSerDe) VerticalFlushDPs(bundle_id, seg, i int64, dps map[int64]float
 		//
 		// Use multi-statement update // TODO make me a funciton!
 		//
+		// NB: These loops are executes at most once because of the if / else we're in.
 		for _, args := range multiStmtUpdateArgs(chunks, []interface{}{bundle_id, seg, i}) {
-			// NB: This loop executes at most once.
-			tx, err := p.dbConn.Begin()
-			if err != nil {
-				return 0, err
-			}
-			defer tx.Commit() // TODO is this actually faster?
+			for _, args := range multiStmtUpdateArgs(vchunks, args) {
 
-			res, err := tx.Stmt(p.sqlUpdateTs).Exec(args...)
-			if err != nil {
-				return 0, err
-			}
-			sqlOps++
-
-			if affected, _ := res.RowsAffected(); affected == 0 { // Insert and try again.
-				if _, err = tx.Stmt(p.sqlInsertTs).Exec(bundle_id, seg, i); err != nil {
+				tx, err := p.dbConn.Begin()
+				if err != nil {
 					return 0, err
 				}
-				if res, err := tx.Stmt(p.sqlUpdateTs).Exec(args...); err != nil {
+				defer tx.Commit() // TODO is this actually faster?
+
+				res, err := tx.Stmt(p.sqlUpdateTs).Exec(args...)
+				if err != nil {
 					return 0, err
-				} else if affected, _ := res.RowsAffected(); affected == 0 {
-					return 0, fmt.Errorf("Unable to update row?")
 				}
 				sqlOps++
+
+				if affected, _ := res.RowsAffected(); affected == 0 { // Insert and try again.
+					if _, err = tx.Stmt(p.sqlInsertTs).Exec(bundle_id, seg, i); err != nil {
+						return 0, err
+					}
+					if res, err := tx.Stmt(p.sqlUpdateTs).Exec(args...); err != nil {
+						return 0, err
+					} else if affected, _ := res.RowsAffected(); affected == 0 {
+						return 0, fmt.Errorf("Unable to update row?")
+					}
+					sqlOps++
+				}
 			}
 		}
 		return sqlOps, nil
@@ -686,15 +748,14 @@ func (p *pgvSerDe) VerticalFlushDPs(bundle_id, seg, i int64, dps map[int64]float
 }
 
 func (p *pgvSerDe) VerticalFlushLatests(bundle_id, seg int64, latests map[int64]time.Time) (sqlOps int, err error) {
+
 	ilatests := make(map[int64]interface{})
 	for k, v := range latests {
 		ilatests[k] = v
 	}
+	chunks := arrayUpdateChunks(ilatests)
 
-	dest, args := arrayUpdateStatement_(ilatests, 3, "latest")
-	args = append([]interface{}{bundle_id, seg}, args...)
-
-	// TODO: Same as with VerticalFlushDPs - prepare and run multiple times?
+	dest, args := singleStmtUpdateArgs(chunks, "latest", 3, []interface{}{bundle_id, seg})
 	stmt := fmt.Sprintf("UPDATE %[1]srra_latest AS rra_latest SET %s WHERE rra_bundle_id = $1 AND seg = $2", p.prefix, dest)
 
 	res, err := p.dbConn.Exec(stmt, args...)

--- a/serde/postgres_common.go
+++ b/serde/postgres_common.go
@@ -40,12 +40,22 @@ func dataSourceFromDsRec(dsr *dsRecord) (*DbDataSource, error) {
 		return nil, err
 	}
 
+	// If LastUpdate was more than HeartBeat ago, to avoid wasting
+	// memory, simply set LU to now. This way everything inbetween
+	// will automatically become NaN because of timestamp versioning.
+	hb := time.Duration(dsr.hbMs) * time.Millisecond
+	lu := *dsr.lastupdate
+	now := time.Now()
+	if lu.Before(now.Add(-hb)) {
+		lu = now
+	}
+
 	ds := NewDbDataSource(dsr.id, ident,
 		rrd.NewDataSource(
 			rrd.DSSpec{
 				Step:       time.Duration(dsr.stepMs) * time.Millisecond,
-				Heartbeat:  time.Duration(dsr.hbMs) * time.Millisecond,
-				LastUpdate: *dsr.lastupdate,
+				Heartbeat:  hb,
+				LastUpdate: lu,
 				Value:      dsr.value,
 				Duration:   time.Duration(dsr.durationMs) * time.Millisecond,
 			},

--- a/serde/postgres_common.go
+++ b/serde/postgres_common.go
@@ -236,7 +236,7 @@ type arrayUpdateChunk struct {
 	vals       []interface{}
 }
 
-func arrayUpdateChunks(m map[int64]float64) []*arrayUpdateChunk {
+func arrayUpdateChunks(m map[int64]interface{}) []*arrayUpdateChunk {
 
 	if len(m) == 0 {
 		return nil

--- a/serde/serde.go
+++ b/serde/serde.go
@@ -71,7 +71,7 @@ type Flusher interface {
 }
 
 type VerticalFlusher interface {
-	VerticalFlushDPs(bunlde_id, seg, i int64, dps map[int64]float64) (int, error)
+	VerticalFlushDPs(bunlde_id, seg, i int64, dps, vers map[int64]interface{}) (int, error)
 	VerticalFlushLatests(bundle_id, seg int64, latests map[int64]time.Time) (int, error)
 }
 


### PR DESCRIPTION
Versioning allows for skipping updates in a round-robin database. Versions exist as a separate array in the ts table which contains a smallint counter aligned on the unix time zero which counts the number of round-robins. Therefore each iteration has a fixed number, and if the version does not match the expected version, the data point is considered NaN.  

The main advantage of this change is that we no longer need to back-fill series that have been inactive for a long time, the issue described in #18. 

Versions will appear as the same number repeated over and over in an array (called `ver`), but on the bright side those should compress really well. Versions add two bytes to every data point (plus some array header overhead), so we are now up to ~10 bytes per data point. 

This change requires a "migration": `ALTER TABLE ts ADD COLUMN ver SMALLINT[] NOT NULL DEFAULT '{}';` (where `ts` is whatever the name of your `ts` table if you are using a prefix). There is no need to populate the `ver` array - if no version exists, versioning is ignored and all is well, eventually tgres will fill in all the versions as RRDs get updated.

Fixes #18 